### PR TITLE
MANTA-4813 mackerel, mola, registrar builds fail attempting to trigger downstream disabled job (fix build)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,7 +49,7 @@ make print-BRANCH print-STAMP all release publish bits-upload''')
                 branch 'master'
             }
             steps {
-                build(job:'joyent-org/mola/master', wait: false)
+                build(job:'joyent-org/manta-mola/master', wait: false)
             }
         }
     }


### PR DESCRIPTION
I tested the build-triggering syntax with
https://jenkins.joyent.us/job/timf-pipeline-test/25/console
which correctly triggered (and in that case, waited for) the manta-mola master build.