### PR TITLE
MANTA-4812 mola build failing with "uncommitted changes in /var/tmp/agent-cache.root/manta-mackerel"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ assets/node_modules
 .*.swp
 .*.swo
 mackerel-pkg-*.tar.gz
+/npm-debug.log


### PR DESCRIPTION
Ignore the npm debug log file as a matter of cleanliness. In earlier
eng.git it would consider the repo dirty.